### PR TITLE
Test ehnancement, integrate Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: php
+
+php:
+    - 7.0
+    - 7.1
+    - 7.2
+    - nightly
+
+matrix:
+    fast_finish: true
+    allow_failures:
+        - php: nightly
+
+before_script:
+    - composer install

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     },
     "require-dev": {
         "ext-xdebug": "*",
-        "phpunit/phpunit": "^5.4",
+        "phpunit/phpunit": "^5.4|^6.5",
         "guzzlehttp/psr7": "^1.4"
     },
 
@@ -23,6 +23,11 @@
     "autoload": {
         "psr-4": {
             "lewiscowles\\Rfc\\": "src"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "lewiscowles\\Rfc\\": "tests"
         }
     }
 }

--- a/src/Attachment.php
+++ b/src/Attachment.php
@@ -7,7 +7,7 @@ use lewiscowles\Rfc\AbstractNode;
 use Psr\Http\Message\StreamInterface;
 
 
-Final class Attachment extends AbstractNode {
+final class Attachment extends AbstractNode {
     private $filename = '';
     private $stream;
     private $mime = '';

--- a/src/Envelope.php
+++ b/src/Envelope.php
@@ -5,7 +5,7 @@ namespace lewiscowles\Rfc;
 use lewiscowles\Rfc\NodeInterface;
 
 
-Final class Envelope implements NodeInterface {
+final class Envelope implements NodeInterface {
 
     const TYPE_FORM_DATA = 'multipart/form-data';
     const TYPE_MIXED = 'multipart/mixed';

--- a/src/FormBody.php
+++ b/src/FormBody.php
@@ -9,7 +9,7 @@ use lewiscowles\Rfc\Attachment;
 use Psr\Http\Message\StreamInterface;
 
 
-Final class FormBody {
+final class FormBody {
 
     private $state;
 

--- a/src/FormInput.php
+++ b/src/FormInput.php
@@ -5,7 +5,7 @@ namespace lewiscowles\Rfc;
 use lewiscowles\Rfc\AbstractNode;
 
 
-Final class FormInput extends AbstractNode {
+final class FormInput extends AbstractNode {
     private $value;
 
     public function __construct($name, $value) {

--- a/tests/BasicTest.php
+++ b/tests/BasicTest.php
@@ -11,6 +11,7 @@ use lewiscowles\Rfc\Envelope;
 use lewiscowles\Rfc\FormBody;
 use lewiscowles\Rfc\NodeInterface;
 
+
 class BasicTest extends TestCase
 {
     const JOE_BLOW_TEXT = 'content-disposition: form-data; name="submitter"'."\n\n".'Joe Blow';

--- a/tests/BasicTest.php
+++ b/tests/BasicTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace lewiscowles\Rfc;
+
 use PHPUnit\Framework\TestCase;
 
 use GuzzleHttp\Psr7\Request;
@@ -43,6 +45,7 @@ class BasicTest extends TestCase
      */
     public function it_accepts_a_form_input() {
         $this->body->addFormInput('number', $this->getValue('number'));
+        $this->assertContains('name="number"', (string) $this->body);
     }
 
     /**
@@ -52,6 +55,9 @@ class BasicTest extends TestCase
         $this->body->addFormInput('number', $this->getValue('number'));
         $this->body->addFormInput('float', $this->getValue('float'));
         $this->body->addFormInput('string', $this->getValue('string'));
+        $this->assertContains('name="number"', (string) $this->body);
+        $this->assertContains('name="float"', (string) $this->body);
+        $this->assertContains('name="string"', (string) $this->body);
     }
 
     /**


### PR DESCRIPTION
# Changed log

- Integrate the Travis CI build. Please see the [Travis build log](https://travis-ci.org/peter279k/rfc1867/builds/370945238).
- Use the class-based PHPUnit namespace.
- Use the ```autoload-dev``` in ```composer.json``` to load the ```tests``` classes automatically.
- Set the namespace for ```tests``` classes.